### PR TITLE
Add nested templates support

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,3 @@
+package main
+
+type templateRenderError error


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6858

With this PR, plugin will examine `files` folder from the template root path and create `Files` map in the same way we do in hive and k8scloudconfig